### PR TITLE
I've added some necessary new parameters to vLLM.

### DIFF
--- a/vllm_dolphin/dolphin.py
+++ b/vllm_dolphin/dolphin.py
@@ -185,6 +185,7 @@ class DolphinMultiModalProcessor(
             prompt_text: str,
             mm_items: MultiModalDataItems,
             hf_processor_mm_kwargs: Mapping[str, object],
+            tokenization_kwargs: Mapping[str, object],
     ) -> bool:
         return False
 
@@ -207,11 +208,12 @@ class DolphinMultiModalProcessor(
             prompt: str,
             mm_data: Mapping[str, object],
             mm_kwargs: Mapping[str, object],
+            tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
         hf_processor = self.info.get_hf_processor()
         if mm_data:
             processed_outputs = super()._call_hf_processor(
-                prompt, mm_data, mm_kwargs)
+                prompt, mm_data, mm_kwargs, tok_kwargs)
             if isinstance(hf_processor, NougatProcessor):
                 processed_outputs["input_ids"] = processed_outputs["labels"]
         else:


### PR DESCRIPTION
Thank you for implementing the Dolphin plugin in vLLM. It has been a great help to the vLLM community. However, with the latest vLLM updates, we need to pass some new, necessary parameters to it. The original plugin implementation causes errors when installed with the latest version of vLLM:

<img width="1204" height="815" alt="Screenshot 2025-08-13 at 4 30 53 PM" src="https://github.com/user-attachments/assets/c0eab0d9-e6da-4d48-849b-5b237b7f6597" />
<img width="1202" height="839" alt="Screenshot 2025-08-13 at 4 31 29 PM" src="https://github.com/user-attachments/assets/d13b77aa-57c7-40ec-904f-7c99f45aa4bd" />

After I add some necessary parameters:
<img width="1824" height="1150" alt="image" src="https://github.com/user-attachments/assets/d5848332-ce82-4c66-b739-39f7383c5937" />
